### PR TITLE
…

### DIFF
--- a/helpstack/res/menu/hs_edit_attachment.xml
+++ b/helpstack/res/menu/hs_edit_attachment.xml
@@ -6,7 +6,7 @@
     <item
         android:id="@+id/attach"
         android:orderInCategory="1"
-        android:showAsAction="always"
+        app:showAsAction="always"
         android:icon="@drawable/hs_action_accept"
         android:title="@string/hs_attach" />
 

--- a/helpstack/src/com/tenmiles/helpstack/activities/EditAttachmentActivity.java
+++ b/helpstack/src/com/tenmiles/helpstack/activities/EditAttachmentActivity.java
@@ -83,7 +83,12 @@ public class EditAttachmentActivity extends ActionBarActivity {
         });
 
         currentPaint = (ImageButton) findViewById(R.id.hs_red_brush);
-        currentPaint.setBackground(getResources().getDrawable(R.drawable.paint_pressed));
+                if(android.os.Build.VERSION.SDK_INT < 16) {
+            currentPaint.setBackgroundDrawable(getResources().getDrawable(ru.appsm.inapphelp.R.drawable.paint_pressed));
+        }
+        else {
+            currentPaint.setBackground(getResources().getDrawable(ru.appsm.inapphelp.R.drawable.paint_pressed));
+        }
         clearChangesTextView = (TextView)findViewById(R.id.clear_change_text);
 
         Intent intent = new Intent();


### PR DESCRIPTION
fallback for setBackground.
wrong attribute on showAsAction.

setBackground added in android lvl 16. http://developer.android.com/reference/android/view/View.html#setBackground(android.graphics.drawable.Drawable)

android:showAsAction="always" doesn't work in android < 11. http://developer.android.com/guide/topics/ui/actionbar.html recomended yourapp:showAsAction