### PR TITLE
Avoid to start the queue again to interrupt started thread

### DIFF
--- a/helpstack/src/com/tenmiles/helpstack/gears/HSHappyfoxGear.java
+++ b/helpstack/src/com/tenmiles/helpstack/gears/HSHappyfoxGear.java
@@ -128,7 +128,6 @@ public class HSHappyfoxGear extends HSGear {
                 request.setTag(cancelTag);
 
 				queue.add(request);
-				queue.start();
 			}
 			else {
 				// Fetch individual section
@@ -153,7 +152,6 @@ public class HSHappyfoxGear extends HSGear {
                 request.setTag(cancelTag);
 
 				queue.add(request);
-				queue.start();
 			}
 
 		}


### PR DESCRIPTION
    HSHelpStack use newRequestQueue of com.android.volley.toolbox.Volley to init Request queue,
    in which has already start the dispather, so in HSHappyfoxGear it's unnecessary to start
    queue again, it will interrupt the first request task when it's already started.